### PR TITLE
Changed signature to output a CSS-valid comment

### DIFF
--- a/tasks/sass_globbing.js
+++ b/tasks/sass_globbing.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('sass_globbing', 'Create file with @import from a configured path', function() {
 
     var importFiles = [];
-    var signature = '// generated with grunt-sass-globbing\n\n';
+    var signature = '/* generated with grunt-sass-globbing */\n\n';
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({


### PR DESCRIPTION
I think my coworker contacted you about this as well. We're using grunt-sass-globbing as the first step in our grunt-postcss process, but it needs to spit out a valid CSS comment for that to work. I just changed the comment format. Thanks!