### PR TITLE
Add add options for custom or no signature.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,22 @@ module.exports = function(grunt) {
         files: {
           'tmp/partials/_partials.scss': 'tmp/partials/**/*.scss'
         }
+      },
+      custom_signature: {
+        files: {
+          'tmp/partials/_partials.scss': 'tmp/partials/**/*.scss'
+        },
+        options: {
+          signature: '// Hello, World!'
+        }
+      },
+      no_signature: {
+        files: {
+          'tmp/partials/_partials.scss': 'tmp/partials/**/*.scss'
+        },
+        options: {
+          signature: false
+        }
       }
     },
 

--- a/tasks/sass_globbing.js
+++ b/tasks/sass_globbing.js
@@ -24,6 +24,12 @@ module.exports = function(grunt) {
       useSingleQuotes: false
     });
 
+    if(typeof options.signature === 'string' && options.signature !== false){
+      signature = options.signature + '\n\n';
+    } else if (options.signature === false) {
+      signature = '';
+    }
+
     var quoteSymbol = '"';
     if (typeof options.useSingleQuotes !== 'undefined' && options.useSingleQuotes === true) {
       quoteSymbol = '\'';

--- a/test/expected/_partials.custom_signature.scss
+++ b/test/expected/_partials.custom_signature.scss
@@ -1,0 +1,6 @@
+// Hello, World!
+
+@import "./impress";
+@import "./post";
+@import "global_data/variables";
+@import "global_data/colors_and_fonts";

--- a/test/expected/_partials.no_signature.scss
+++ b/test/expected/_partials.no_signature.scss
@@ -1,0 +1,4 @@
+@import "./impress";
+@import "./post";
+@import "global_data/variables";
+@import "global_data/colors_and_fonts";

--- a/test/sass_globbing_test.js
+++ b/test/sass_globbing_test.js
@@ -91,5 +91,27 @@ exports.sass_globbing = {
 
       test.done();
     });
+  },
+  custom_signature: function(test) {
+    test.expect(1);
+
+    exec('grunt sass_globbing:custom_signature', execOptions, function(error, stdout) {
+      var actual = grunt.file.read('tmp/partials/_partials.scss');
+      var expected = grunt.file.read('test/expected/_partials.custom_signature.scss');
+      test.equal(actual, expected, 'generated partials/partials.scss is correct');
+
+      test.done();
+    });
+  },
+  no_signature: function(test) {
+    test.expect(1);
+
+    exec('grunt sass_globbing:no_signature', execOptions, function(error, stdout) {
+      var actual = grunt.file.read('tmp/partials/_partials.scss');
+      var expected = grunt.file.read('test/expected/_partials.no_signature.scss');
+      test.equal(actual, expected, 'generated partials/partials.scss is correct');
+
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
I've added the option to customize the signature at the top of each generated file, or to exclude it completely.

My primary use case for this change is compatibility with scss-lint settings (prefer `//` over `/* */`), as well as custom messages for project specific instructions on how to rebuild the files.

- To use the default signature, no additional options need to be set.
- To not include a signature, set `options.signature` to `false`.
- To set a custom signature, set `options.signature` to your signature.

```
options: {
  signature: "// This is a generated file.\n// To regenerate, run `grunt sass_globbing`."
}
```
