### PR TITLE
Fixed a (code) typo in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ grunt.initConfig({
         'src/_variablesMap.scss': 'src/variables/**/*.scss',
       },
       options: {
-        useSingleQuotes: false
+        useSingleQuotes: false,
         signature: '// Hello, World!'
       }
     }


### PR DESCRIPTION
Fixed lack of comma on line 68 of readme, which caused grunt to fall over with 'unexpected identifier' when it reached the next line (signature).