### PR TITLE
Add test for excluding a file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,11 @@ module.exports = function(grunt) {
           'tmp/partials.scss': 'tmp/partials/**/*.scss'
         }
       },
+      exclude_file: {
+        files: {
+          'tmp/partials.scss': ['tmp/partials/**/*.scss', '!tmp/**/_post.scss']
+        }
+      },
       single_quotes: {
         files: {
           'tmp/other-single.scss': 'tmp/other/**/*.scss'

--- a/test/expected/_partials.exclude_file.scss
+++ b/test/expected/_partials.exclude_file.scss
@@ -1,0 +1,5 @@
+/* generated with grunt-sass-globbing */
+
+@import "partials/impress";
+@import "partials/global_data/variables";
+@import "partials/global_data/colors_and_fonts";

--- a/test/sass_globbing_test.js
+++ b/test/sass_globbing_test.js
@@ -43,6 +43,17 @@ exports.sass_globbing = {
       test.done();
     });
   },
+  exclude_file: function(test) {
+    test.expect(1);
+
+    exec('grunt sass_globbing:exclude_file', execOptions, function(error, stdout) {
+      var actual = grunt.file.read('tmp/partials.scss');
+      var expected = grunt.file.read('test/expected/_partials.exclude_file.scss');
+      test.equal(actual, expected, 'generated partials.scss is correct');
+
+      test.done();
+    });
+  },
   single_quotes: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Seems that excluding a file is already supported by Grunt. So, here's a test to prove it.